### PR TITLE
name: "null" 

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,9 @@ function FaviconsWebpackPlugin (options) {
 
 FaviconsWebpackPlugin.prototype.apply = function (compiler) {
   var self = this;
-  if (!self.options.title) {
+  if (!self.options.config.appName) {
     self.options.config.appName = guessAppName(compiler.context);
-  }
+  } 
 
   // Generate the favicons
   var compilationResult;

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function FaviconsWebpackPlugin (options) {
 FaviconsWebpackPlugin.prototype.apply = function (compiler) {
   var self = this;
   if (!self.options.title) {
-    self.options.title = guessAppName(compiler.context);
+    self.options.config.appName = guessAppName(compiler.context);
   }
 
   // Generate the favicons


### PR DESCRIPTION
fix the bug when not providing a config.appName
I think this is a much better api than upstream.
We might actually be able to merge this. 